### PR TITLE
Fix selection and dragging independent of active tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,7 +722,6 @@
       // Unified click handler on the <g> itself
       const selectHandler = (e) => {
         e.stopPropagation();
-        if (currentTool !== "select") return;
 
         // Deselect any previously selected group
         document.querySelectorAll("g.selected").forEach((g) => {
@@ -756,7 +755,6 @@
       let isDragging = false;
       let startX, startY;
       wrapper.addEventListener("mousedown", (e) => {
-        if (currentTool !== "select") return;
         isDragging = true;
         startX = e.clientX;
         startY = e.clientY;
@@ -983,7 +981,6 @@
           <button class="delete-btn text-xs text-red-400 hover:text-red-600">🗑️</button>
         `;
         item.addEventListener("click", () => {
-          if (currentTool !== "select") return;
           node.dispatchEvent(new Event("click"));
         });
         item.querySelector(".delete-btn").addEventListener("click", (ev) => {
@@ -1006,7 +1003,6 @@
 
     // DESELECT ON BACKGROUND CLICK
     canvas.addEventListener("click", (e) => {
-      if (currentTool !== "select") return;
       document
         .querySelectorAll("g.selected")
         .forEach((g) => {


### PR DESCRIPTION
## Summary
- let canvas items be selected and dragged regardless of current tool
- allow layer panel entries to select items without requiring the select tool
- background click always clears selection

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841bfcb658c83219439310558b8b573