### PR TITLE
Improve animation workflow, SVG import, and canvas navigation

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,6 +1,7 @@
 const SVG_NS = "http://www.w3.org/2000/svg";
 const stage = document.getElementById("stage");
 const statusEl = document.getElementById("status");
+const INITIAL_VIEWBOX = { x: 0, y: 0, w: 1200, h: 760 };
 
 const state = {
   tool: "select",
@@ -11,15 +12,56 @@ const state = {
   dragOrigin: null,
   itemOrigin: null,
   pathPoints: [],
-  shapeCount: 0
+  shapeCount: 0,
+  panning: false,
+  panStart: null,
+  viewBoxStart: null,
+  spaceDown: false,
+  history: [],
+  historyIndex: -1
 };
 
 const byId = (id) => document.getElementById(id);
+const getViewBox = () => {
+  const [x, y, w, h] = stage.getAttribute("viewBox").split(" ").map(Number);
+  return { x, y, w, h };
+};
+const setViewBox = ({ x, y, w, h }) => stage.setAttribute("viewBox", `${x} ${y} ${w} ${h}`);
+
 const getStyles = () => ({
   fill: byId("fillColor").value,
   stroke: byId("strokeColor").value,
   strokeWidth: byId("strokeWidth").value
 });
+
+const snapPoint = (x, y) => {
+  if (!byId("snapToggle").checked) return { x, y };
+  const grid = Number(byId("gridSize").value) || 24;
+  return {
+    x: Math.round(x / grid) * grid,
+    y: Math.round(y / grid) * grid
+  };
+};
+
+const saveHistory = () => {
+  const snapshot = {
+    stage: stage.innerHTML,
+    viewBox: stage.getAttribute("viewBox")
+  };
+  state.history = state.history.slice(0, state.historyIndex + 1);
+  state.history.push(snapshot);
+  if (state.history.length > 80) state.history.shift();
+  state.historyIndex = state.history.length - 1;
+};
+
+const restoreHistory = (index) => {
+  const shot = state.history[index];
+  if (!shot) return;
+  stage.innerHTML = shot.stage;
+  stage.setAttribute("viewBox", shot.viewBox);
+  state.historyIndex = index;
+  selectElement(null);
+};
 
 const tabs = document.querySelectorAll(".tab");
 const panels = document.querySelectorAll(".panel");
@@ -33,14 +75,14 @@ tabs.forEach((tab) => {
 });
 
 const tools = document.querySelectorAll(".tool");
+const activateTool = (tool) => {
+  state.tool = tool;
+  state.pathPoints = [];
+  tools.forEach((b) => b.classList.toggle("is-active", b.dataset.tool === tool));
+  statusEl.textContent = `Tool: ${state.tool}`;
+};
 tools.forEach((btn) => {
-  btn.addEventListener("click", () => {
-    tools.forEach((b) => b.classList.remove("is-active"));
-    btn.classList.add("is-active");
-    state.tool = btn.dataset.tool;
-    state.pathPoints = [];
-    statusEl.textContent = `Tool: ${state.tool}`;
-  });
+  btn.addEventListener("click", () => activateTool(btn.dataset.tool));
 });
 
 const pointOnStage = (evt) => {
@@ -91,9 +133,34 @@ const createShape = (tool, x, y) => {
   return el;
 };
 
-stage.addEventListener("mousedown", (evt) => {
+const startPan = (evt) => {
+  state.panning = true;
+  state.panStart = pointOnStage(evt);
+  state.viewBoxStart = getViewBox();
+};
+
+const panTo = (evt) => {
   const p = pointOnStage(evt);
+  const dx = p.x - state.panStart.x;
+  const dy = p.y - state.panStart.y;
+  const next = {
+    x: state.viewBoxStart.x - dx,
+    y: state.viewBoxStart.y - dy,
+    w: state.viewBoxStart.w,
+    h: state.viewBoxStart.h
+  };
+  setViewBox(next);
+};
+
+stage.addEventListener("mousedown", (evt) => {
+  const pRaw = pointOnStage(evt);
+  const p = snapPoint(pRaw.x, pRaw.y);
   state.start = p;
+
+  if (evt.button === 1 || state.tool === "pan" || state.spaceDown) {
+    startPan(evt);
+    return;
+  }
 
   if (state.tool === "select") {
     const target = evt.target !== stage ? evt.target : null;
@@ -119,7 +186,13 @@ stage.addEventListener("mousedown", (evt) => {
 });
 
 stage.addEventListener("mousemove", (evt) => {
-  const p = pointOnStage(evt);
+  const pRaw = pointOnStage(evt);
+  const p = snapPoint(pRaw.x, pRaw.y);
+
+  if (state.panning) {
+    panTo(evt);
+    return;
+  }
 
   if (state.dragging && state.selected) {
     const dx = p.x - state.dragOrigin.x;
@@ -167,12 +240,53 @@ stage.addEventListener("mousemove", (evt) => {
 });
 
 window.addEventListener("mouseup", () => {
+  const shouldSave = state.drawing || state.dragging || state.panning;
   state.drawing = null;
   state.start = null;
   state.dragging = false;
   state.dragOrigin = null;
   state.itemOrigin = null;
+  state.panning = false;
+  state.panStart = null;
+  state.viewBoxStart = null;
+  if (shouldSave) saveHistory();
 });
+
+window.addEventListener("keydown", (evt) => {
+  if (evt.code === "Space") {
+    state.spaceDown = true;
+    evt.preventDefault();
+  }
+  if ((evt.ctrlKey || evt.metaKey) && evt.key.toLowerCase() === "z") {
+    evt.preventDefault();
+    if (evt.shiftKey) {
+      if (state.historyIndex < state.history.length - 1) restoreHistory(state.historyIndex + 1);
+    } else if (state.historyIndex > 0) {
+      restoreHistory(state.historyIndex - 1);
+    }
+  }
+});
+
+window.addEventListener("keyup", (evt) => {
+  if (evt.code === "Space") state.spaceDown = false;
+});
+
+stage.addEventListener("wheel", (evt) => {
+  evt.preventDefault();
+  const vb = getViewBox();
+  const zoomFactor = evt.deltaY < 0 ? 0.92 : 1.08;
+  const pointer = pointOnStage(evt);
+  const nextW = vb.w * zoomFactor;
+  const nextH = vb.h * zoomFactor;
+  const ratioX = (pointer.x - vb.x) / vb.w;
+  const ratioY = (pointer.y - vb.y) / vb.h;
+  setViewBox({
+    x: pointer.x - nextW * ratioX,
+    y: pointer.y - nextH * ratioY,
+    w: nextW,
+    h: nextH
+  });
+}, { passive: false });
 
 byId("extrudeBtn").addEventListener("click", () => {
   if (!state.selected) return;
@@ -192,7 +306,27 @@ byId("extrudeBtn").addEventListener("click", () => {
   group.appendChild(top);
   stage.replaceChild(group, base);
   selectElement(group);
+  saveHistory();
   statusEl.textContent = "Extruded into layered group";
+});
+
+const templates = {
+  slideRight: { type: "translate", from: "0 0", to: "140 0", dur: 1.8 },
+  pulse: { type: "scale", from: "1", to: "1.25", dur: 1.2 },
+  spin: { type: "rotate", from: "0 200 200", to: "360 200 200", dur: 2.4 },
+  fade: { type: "opacity", from: "0.15", to: "1", dur: 1.5 },
+  bounce: { type: "translate", from: "0 0", to: "0 -90", dur: 0.8 }
+};
+
+byId("applyTemplateBtn").addEventListener("click", () => {
+  const name = byId("animTemplate").value;
+  if (name === "custom") return;
+  const tpl = templates[name];
+  byId("animType").value = tpl.type;
+  byId("animFrom").value = tpl.from;
+  byId("animTo").value = tpl.to;
+  byId("animDur").value = tpl.dur;
+  statusEl.textContent = `Loaded template: ${name}`;
 });
 
 const appendAnimation = () => {
@@ -218,6 +352,7 @@ const appendAnimation = () => {
   anim.setAttribute("dur", `${dur}s`);
   anim.setAttribute("repeatCount", "indefinite");
   state.selected.appendChild(anim);
+  saveHistory();
 
   const li = document.createElement("li");
   li.textContent = `${state.selected.dataset.name || state.selected.tagName}: ${type} ${from} → ${to} (${dur}s)`;
@@ -225,18 +360,99 @@ const appendAnimation = () => {
 };
 
 byId("addAnimBtn").addEventListener("click", appendAnimation);
-byId("previewBtn").addEventListener("click", () => {
-  const clone = stage.cloneNode(true);
-  stage.replaceWith(clone);
-  clone.setAttribute("id", "stage");
-  statusEl.textContent = "Animation restarted";
-  window.location.reload();
+byId("clearAnimBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  state.selected.querySelectorAll("animate, animateTransform").forEach((a) => a.remove());
+  byId("animList").innerHTML = "";
+  saveHistory();
+});
+
+byId("playBtn").addEventListener("click", () => stage.unpauseAnimations());
+byId("pauseBtn").addEventListener("click", () => stage.pauseAnimations());
+byId("stopBtn").addEventListener("click", () => {
+  stage.setCurrentTime(0);
+  stage.pauseAnimations();
+});
+
+byId("duplicateBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  const clone = state.selected.cloneNode(true);
+  clone.classList.remove("selected");
+  clone.dataset.name = `Shape ${++state.shapeCount}`;
+  clone.setAttribute("transform", "translate(20,20)");
+  stage.appendChild(clone);
+  selectElement(clone);
+  saveHistory();
+});
+
+byId("deleteBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  state.selected.remove();
+  selectElement(null);
+  saveHistory();
+});
+
+byId("frontBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  stage.appendChild(state.selected);
+  saveHistory();
+});
+
+byId("backBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  stage.prepend(state.selected);
+  saveHistory();
+});
+
+byId("undoBtn").addEventListener("click", () => {
+  if (state.historyIndex > 0) restoreHistory(state.historyIndex - 1);
+});
+
+byId("redoBtn").addEventListener("click", () => {
+  if (state.historyIndex < state.history.length - 1) restoreHistory(state.historyIndex + 1);
+});
+
+byId("zoomInBtn").addEventListener("click", () => {
+  const vb = getViewBox();
+  setViewBox({ x: vb.x + vb.w * 0.04, y: vb.y + vb.h * 0.04, w: vb.w * 0.92, h: vb.h * 0.92 });
+  saveHistory();
+});
+
+byId("zoomOutBtn").addEventListener("click", () => {
+  const vb = getViewBox();
+  setViewBox({ x: vb.x - vb.w * 0.04, y: vb.y - vb.h * 0.04, w: vb.w * 1.08, h: vb.h * 1.08 });
+  saveHistory();
+});
+
+byId("resetViewBtn").addEventListener("click", () => {
+  setViewBox(INITIAL_VIEWBOX);
+  saveHistory();
+});
+
+byId("importSvg").addEventListener("change", async (evt) => {
+  const file = evt.target.files?.[0];
+  if (!file) return;
+  const text = await file.text();
+  const doc = new DOMParser().parseFromString(text, "image/svg+xml");
+  const imported = doc.querySelector("svg");
+  if (!imported) return;
+
+  while (imported.firstChild) {
+    const child = imported.firstChild;
+    imported.removeChild(child);
+    stage.appendChild(document.importNode(child, true));
+  }
+
+  saveHistory();
+  statusEl.textContent = `Imported: ${file.name}`;
+  evt.target.value = "";
 });
 
 byId("clearBtn").addEventListener("click", () => {
   while (stage.firstChild) stage.removeChild(stage.firstChild);
   selectElement(null);
   byId("animList").innerHTML = "";
+  saveHistory();
 });
 
 byId("exportBtn").addEventListener("click", () => {
@@ -250,3 +466,5 @@ byId("exportBtn").addEventListener("click", () => {
   URL.revokeObjectURL(url);
   statusEl.textContent = "Exported SVG";
 });
+
+saveHistory();

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
           <label>Tool</label>
           <div class="tool-row">
             <button class="tool is-active" data-tool="select">Select</button>
+            <button class="tool" data-tool="pan">Pan</button>
             <button class="tool" data-tool="rect">Rect</button>
             <button class="tool" data-tool="circle">Circle</button>
             <button class="tool" data-tool="path">Path</button>
@@ -36,12 +37,43 @@
           <label>Stroke width</label>
           <input id="strokeWidth" type="range" min="1" max="12" value="2" />
 
+          <label class="inline-row">
+            <input id="snapToggle" type="checkbox" /> Snap to grid
+          </label>
+          <label>Grid size</label>
+          <input id="gridSize" type="number" min="4" max="100" value="24" />
+
           <label>Extrude depth</label>
           <input id="extrudeDepth" type="range" min="0" max="20" value="6" />
           <button id="extrudeBtn">Extrude selected</button>
+
+          <div class="button-row">
+            <button id="duplicateBtn">Duplicate</button>
+            <button id="deleteBtn">Delete</button>
+          </div>
+          <div class="button-row">
+            <button id="frontBtn">Bring front</button>
+            <button id="backBtn">Send back</button>
+          </div>
+
+          <div class="button-row">
+            <button id="undoBtn">Undo</button>
+            <button id="redoBtn">Redo</button>
+          </div>
         </section>
 
         <section class="panel" data-panel="animate">
+          <label>Animation template</label>
+          <select id="animTemplate">
+            <option value="custom">Custom</option>
+            <option value="slideRight">Slide right</option>
+            <option value="pulse">Pulse</option>
+            <option value="spin">Spin</option>
+            <option value="fade">Fade in/out</option>
+            <option value="bounce">Bounce</option>
+          </select>
+          <button id="applyTemplateBtn">Apply template</button>
+
           <label>Animation type</label>
           <select id="animType">
             <option value="translate">Translate</option>
@@ -59,16 +91,32 @@
           <label>Duration (s)</label>
           <input id="animDur" type="number" min="0.1" step="0.1" value="2" />
 
-          <button id="addAnimBtn">Add key animation</button>
-          <button id="previewBtn">Preview all</button>
+          <div class="button-row">
+            <button id="addAnimBtn">Add animation</button>
+            <button id="clearAnimBtn">Clear anims</button>
+          </div>
+          <div class="button-row triple">
+            <button id="playBtn">Play</button>
+            <button id="pauseBtn">Pause</button>
+            <button id="stopBtn">Stop</button>
+          </div>
 
           <ul id="animList"></ul>
         </section>
 
         <section class="panel" data-panel="export">
+          <label>Import SVG</label>
+          <input id="importSvg" type="file" accept=".svg,image/svg+xml" />
+
+          <div class="button-row">
+            <button id="zoomInBtn">Zoom +</button>
+            <button id="zoomOutBtn">Zoom −</button>
+            <button id="resetViewBtn">Reset view</button>
+          </div>
+
           <button id="clearBtn">Clear canvas</button>
           <button id="exportBtn">Export SVG</button>
-          <p class="hint">Keeps shapes + animation tags.</p>
+          <p class="hint">Pan with Pan tool or hold Space + drag. Wheel to zoom.</p>
         </section>
       </aside>
 

--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@ body {
 
 .app {
   display: grid;
-  grid-template-columns: 300px 1fr;
+  grid-template-columns: 320px 1fr;
   min-height: 100vh;
 }
 
@@ -25,6 +25,7 @@ body {
   border-right: 1px solid var(--line);
   background: var(--panel);
   padding: 16px;
+  overflow-y: auto;
 }
 
 h1 { margin: 0; font-size: 1.1rem; letter-spacing: 0.03em; }
@@ -61,10 +62,31 @@ label {
   font-size: 0.8rem;
 }
 
+.inline-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.inline-row input {
+  width: auto;
+}
+
 .tool-row {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 6px;
+}
+
+.button-row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.button-row.triple {
+  grid-template-columns: repeat(3, 1fr);
 }
 
 #animList {


### PR DESCRIPTION
### Motivation
- Make the Animate and Draw panels more useful by adding reusable animation templates, playback controls, and a smoother canvas navigation/editing experience.
- Enable importing external artwork (SVG) and add common editor features like snapping, duplication, layer ordering, and undo/redo to speed iteration and prototyping.

### Description
- Implemented viewBox-based canvas navigation with a dedicated Pan tool, space+drag panning, mouse-wheel zoom, zoom in/out/reset controls, and persistent view state handling in `assets/app.js` and `index.html`.
- Added `importSvg` file input to parse and import external SVG content into the stage and updated export/clear flows to preserve animations and elements.
- Added animation templates (slide/pulse/spin/fade/bounce) with an `Apply template` button, playback controls (`Play`/`Pause`/`Stop`), and a clear animations action so templates can be applied and then attached to selected elements.
- Introduced snap-to-grid toggle and grid size, duplicate/delete, bring to front/send to back, extrude/saveHistory, and an undo/redo history stack with `saveHistory`/`restoreHistory`, plus sidebar and stylesheet updates to expose these controls.

### Testing
- Ran `node --check assets/app.js` to validate script syntax and it succeeded.
- Executed an automated Playwright script against a local server to exercise the new tools and captured a UI screenshot (successful run and screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fa0ba4c08321a41983d500e7a7af)