### PR TITLE
Enhance Animate tab: SVG import, pan/zoom, templates, and editor power-tools

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2,6 +2,8 @@ const SVG_NS = "http://www.w3.org/2000/svg";
 const stage = document.getElementById("stage");
 const statusEl = document.getElementById("status");
 
+const INITIAL_VIEWBOX = { x: 0, y: 0, w: 1200, h: 760 };
+
 const state = {
   tool: "select",
   selected: null,
@@ -11,7 +13,15 @@ const state = {
   dragOrigin: null,
   itemOrigin: null,
   pathPoints: [],
-  shapeCount: 0
+  shapeCount: 0,
+  nextId: 1,
+  snapEnabled: false,
+  spacePan: false,
+  panning: false,
+  panOrigin: null,
+  viewBox: { ...INITIAL_VIEWBOX },
+  history: [],
+  redo: []
 };
 
 const byId = (id) => document.getElementById(id);
@@ -20,6 +30,39 @@ const getStyles = () => ({
   stroke: byId("strokeColor").value,
   strokeWidth: byId("strokeWidth").value
 });
+
+const easingMap = {
+  linear: null,
+  ease: "0.25 0.1 0.25 1",
+  "ease-in": "0.42 0 1 1",
+  "ease-out": "0 0 0.58 1",
+  "ease-in-out": "0.42 0 0.58 1"
+};
+
+const templates = {
+  float: [
+    { type: "translate", from: "0 0", to: "0 -25", dur: 2.2 }
+  ],
+  pulse: [
+    { type: "scale", from: "1 1", to: "1.12 1.12", dur: 1.1 }
+  ],
+  spin: [
+    { type: "rotate", from: "0 300 200", to: "360 300 200", dur: 2.4 }
+  ],
+  fadeInOut: [
+    { type: "opacity", from: "1", to: "0.2", dur: 1.6 }
+  ],
+  bounce: [
+    { type: "translate", from: "0 0", to: "0 -55", dur: 0.7 }
+  ]
+};
+
+const setViewBox = ({ x, y, w, h }) => {
+  state.viewBox = { x, y, w, h };
+  stage.setAttribute("viewBox", `${x} ${y} ${w} ${h}`);
+};
+
+setViewBox(INITIAL_VIEWBOX);
 
 const tabs = document.querySelectorAll(".tab");
 const panels = document.querySelectorAll(".panel");
@@ -50,6 +93,14 @@ const pointOnStage = (evt) => {
   return pt.matrixTransform(stage.getScreenCTM().inverse());
 };
 
+const snap = (value) => {
+  if (!state.snapEnabled) return value;
+  const grid = Math.max(4, Number(byId("gridSize").value || 24));
+  return Math.round(value / grid) * grid;
+};
+
+const snapPoint = ({ x, y }) => ({ x: snap(x), y: snap(y) });
+
 const applyStyles = (el) => {
   const styles = getStyles();
   el.setAttribute("fill", styles.fill);
@@ -57,10 +108,47 @@ const applyStyles = (el) => {
   el.setAttribute("stroke-width", styles.strokeWidth);
 };
 
+const refreshLayerList = () => {
+  const layerList = byId("layerList");
+  if (!layerList) return;
+  layerList.innerHTML = "";
+  const layers = [...stage.children].reverse();
+  layers.forEach((el) => {
+    if (el.tagName === "defs") return;
+    const li = document.createElement("li");
+    const label = el.dataset.name || `${el.tagName} ${el.dataset.id || ""}`.trim();
+    li.textContent = label;
+    if (state.selected === el) li.classList.add("is-selected");
+    li.addEventListener("click", () => selectElement(el));
+    layerList.appendChild(li);
+  });
+};
+
 const selectElement = (el) => {
   if (state.selected) state.selected.classList.remove("selected");
   state.selected = el;
   if (el) el.classList.add("selected");
+  refreshLayerList();
+};
+
+const recordHistory = () => {
+  state.history.push({
+    markup: stage.innerHTML,
+    viewBox: { ...state.viewBox },
+    shapeCount: state.shapeCount,
+    nextId: state.nextId
+  });
+  if (state.history.length > 120) state.history.shift();
+  state.redo = [];
+};
+
+const restoreState = (snapshot) => {
+  stage.innerHTML = snapshot.markup;
+  setViewBox(snapshot.viewBox);
+  state.shapeCount = snapshot.shapeCount;
+  state.nextId = snapshot.nextId;
+  selectElement(null);
+  refreshLayerList();
 };
 
 const createShape = (tool, x, y) => {
@@ -85,20 +173,42 @@ const createShape = (tool, x, y) => {
     state.pathPoints = [[x, y]];
   }
   if (!el) return null;
+  el.dataset.id = String(state.nextId++);
   el.dataset.name = `Shape ${++state.shapeCount}`;
   applyStyles(el);
   stage.appendChild(el);
+  refreshLayerList();
   return el;
 };
 
+const normalizeSelectable = (target) => {
+  if (!target || target === stage) return null;
+  let node = target;
+  while (node && node.parentNode && node.parentNode !== stage) node = node.parentNode;
+  return node && node !== stage ? node : null;
+};
+
+const parsePoints = (raw) => raw.trim().split(" ").map((pair) => pair.split(",").map(Number));
+
 stage.addEventListener("mousedown", (evt) => {
-  const p = pointOnStage(evt);
+  const p = snapPoint(pointOnStage(evt));
   state.start = p;
 
+  const shouldPan = state.tool === "pan" || evt.button === 1 || state.spacePan;
+  if (shouldPan) {
+    recordHistory();
+    state.panning = true;
+    state.panOrigin = pointOnStage(evt);
+    stage.classList.add("is-panning");
+    statusEl.textContent = "Panning viewport";
+    return;
+  }
+
   if (state.tool === "select") {
-    const target = evt.target !== stage ? evt.target : null;
+    const target = normalizeSelectable(evt.target);
     selectElement(target);
     if (target) {
+      recordHistory();
       state.dragging = true;
       state.dragOrigin = p;
       if (target.tagName === "rect") {
@@ -108,18 +218,33 @@ stage.addEventListener("mousedown", (evt) => {
         state.itemOrigin = { x: +target.getAttribute("cx"), y: +target.getAttribute("cy") };
       }
       if (target.tagName === "polyline") {
-        state.itemOrigin = target.getAttribute("points");
+        state.itemOrigin = parsePoints(target.getAttribute("points"));
       }
     }
     return;
   }
 
+  recordHistory();
   state.drawing = createShape(state.tool, p.x, p.y);
   selectElement(state.drawing);
 });
 
 stage.addEventListener("mousemove", (evt) => {
-  const p = pointOnStage(evt);
+  const p = snapPoint(pointOnStage(evt));
+
+  if (state.panning) {
+    const next = pointOnStage(evt);
+    const dx = next.x - state.panOrigin.x;
+    const dy = next.y - state.panOrigin.y;
+    setViewBox({
+      x: state.viewBox.x - dx,
+      y: state.viewBox.y - dy,
+      w: state.viewBox.w,
+      h: state.viewBox.h
+    });
+    state.panOrigin = next;
+    return;
+  }
 
   if (state.dragging && state.selected) {
     const dx = p.x - state.dragOrigin.x;
@@ -134,12 +259,7 @@ stage.addEventListener("mousemove", (evt) => {
       el.setAttribute("cy", state.itemOrigin.y + dy);
     }
     if (el.tagName === "polyline") {
-      const moved = state.itemOrigin
-        .trim()
-        .split(" ")
-        .map((pair) => pair.split(",").map(Number))
-        .map(([x, y]) => `${x + dx},${y + dy}`)
-        .join(" ");
+      const moved = state.itemOrigin.map(([x, y]) => `${x + dx},${y + dy}`).join(" ");
       el.setAttribute("points", moved);
     }
     return;
@@ -172,17 +292,58 @@ window.addEventListener("mouseup", () => {
   state.dragging = false;
   state.dragOrigin = null;
   state.itemOrigin = null;
+  state.panning = false;
+  state.panOrigin = null;
+  stage.classList.remove("is-panning");
+  statusEl.textContent = `Tool: ${state.tool}`;
+  refreshLayerList();
+});
+
+window.addEventListener("keydown", (evt) => {
+  if (evt.code === "Space") {
+    state.spacePan = true;
+    evt.preventDefault();
+  }
+});
+
+window.addEventListener("keyup", (evt) => {
+  if (evt.code === "Space") state.spacePan = false;
+});
+
+stage.addEventListener("wheel", (evt) => {
+  evt.preventDefault();
+  const delta = evt.deltaY > 0 ? 1.1 : 0.9;
+  const nextW = Math.max(200, Math.min(3000, state.viewBox.w * delta));
+  const nextH = Math.max(120, Math.min(2200, state.viewBox.h * delta));
+  setViewBox({ ...state.viewBox, w: nextW, h: nextH });
+});
+
+byId("zoomInBtn").addEventListener("click", () => {
+  setViewBox({ ...state.viewBox, w: state.viewBox.w * 0.9, h: state.viewBox.h * 0.9 });
+});
+
+byId("zoomOutBtn").addEventListener("click", () => {
+  setViewBox({ ...state.viewBox, w: state.viewBox.w * 1.1, h: state.viewBox.h * 1.1 });
+});
+
+byId("resetViewBtn").addEventListener("click", () => setViewBox(INITIAL_VIEWBOX));
+
+byId("snapToggle").addEventListener("click", () => {
+  state.snapEnabled = !state.snapEnabled;
+  byId("snapToggle").textContent = `Snap: ${state.snapEnabled ? "on" : "off"}`;
 });
 
 byId("extrudeBtn").addEventListener("click", () => {
   if (!state.selected) return;
+  recordHistory();
   const depth = Number(byId("extrudeDepth").value);
   const base = state.selected;
   const group = document.createElementNS(SVG_NS, "g");
+  group.dataset.id = String(state.nextId++);
+  group.dataset.name = `${base.dataset.name || base.tagName} Extrude`;
   for (let i = depth; i >= 1; i -= 1) {
     const clone = base.cloneNode(true);
     clone.classList.remove("selected");
-    clone.removeAttribute("data-name");
     clone.setAttribute("opacity", (0.04 + i * 0.03).toFixed(2));
     clone.setAttribute("transform", `translate(${i * 2}, ${i * 2})`);
     group.appendChild(clone);
@@ -192,15 +353,15 @@ byId("extrudeBtn").addEventListener("click", () => {
   group.appendChild(top);
   stage.replaceChild(group, base);
   selectElement(group);
+  refreshLayerList();
   statusEl.textContent = "Extruded into layered group";
 });
 
-const appendAnimation = () => {
+const applyAnimation = ({ type, from, to, dur }) => {
   if (!state.selected) return;
-  const type = byId("animType").value;
-  const from = byId("animFrom").value.trim();
-  const to = byId("animTo").value.trim();
-  const dur = Number(byId("animDur").value || 2);
+  const delay = Number(byId("animDelay").value || 0);
+  const repeat = byId("animRepeat").value;
+  const ease = byId("animEase").value;
 
   let anim;
   if (type === "opacity") {
@@ -216,27 +377,155 @@ const appendAnimation = () => {
   anim.setAttribute("from", from);
   anim.setAttribute("to", to);
   anim.setAttribute("dur", `${dur}s`);
-  anim.setAttribute("repeatCount", "indefinite");
+  anim.setAttribute("begin", `${delay}s`);
+  anim.setAttribute("repeatCount", repeat);
+
+  if (ease !== "linear") {
+    anim.setAttribute("calcMode", "spline");
+    anim.setAttribute("keyTimes", "0;1");
+    anim.setAttribute("keySplines", easingMap[ease]);
+  }
+
   state.selected.appendChild(anim);
 
   const li = document.createElement("li");
-  li.textContent = `${state.selected.dataset.name || state.selected.tagName}: ${type} ${from} → ${to} (${dur}s)`;
+  li.textContent = `${state.selected.dataset.name || state.selected.tagName}: ${type} ${from} → ${to} (${dur}s, ${ease})`;
   byId("animList").appendChild(li);
 };
 
+const appendAnimation = () => {
+  if (!state.selected) return;
+  recordHistory();
+  applyAnimation({
+    type: byId("animType").value,
+    from: byId("animFrom").value.trim(),
+    to: byId("animTo").value.trim(),
+    dur: Number(byId("animDur").value || 2)
+  });
+};
+
 byId("addAnimBtn").addEventListener("click", appendAnimation);
+byId("applyTemplateBtn").addEventListener("click", () => {
+  const template = byId("animTemplate").value;
+  if (!state.selected || !template || !templates[template]) return;
+  recordHistory();
+  templates[template].forEach(applyAnimation);
+  statusEl.textContent = `Template '${template}' applied`;
+});
+
 byId("previewBtn").addEventListener("click", () => {
-  const clone = stage.cloneNode(true);
-  stage.replaceWith(clone);
-  clone.setAttribute("id", "stage");
-  statusEl.textContent = "Animation restarted";
-  window.location.reload();
+  const anims = stage.querySelectorAll("animate, animateTransform");
+  anims.forEach((anim) => {
+    if (typeof anim.beginElement === "function") anim.beginElement();
+  });
+  statusEl.textContent = "Animation preview restarted";
+});
+
+const assignElementMetadata = (el) => {
+  if (el.nodeType !== 1) return;
+  if (!el.dataset.id) el.dataset.id = String(state.nextId++);
+  if (!el.dataset.name) {
+    state.shapeCount += 1;
+    el.dataset.name = `Imported ${el.tagName} ${state.shapeCount}`;
+  }
+};
+
+const importSvgText = (text) => {
+  const doc = new DOMParser().parseFromString(text, "image/svg+xml");
+  const svg = doc.querySelector("svg");
+  if (!svg) return;
+  recordHistory();
+  [...svg.children].forEach((child) => {
+    const imported = document.importNode(child, true);
+    assignElementMetadata(imported);
+    stage.appendChild(imported);
+  });
+  selectElement(null);
+  refreshLayerList();
+  statusEl.textContent = "SVG imported";
+};
+
+byId("importSvgInput").addEventListener("change", async (evt) => {
+  const file = evt.target.files?.[0];
+  if (!file) return;
+  const text = await file.text();
+  importSvgText(text);
+  evt.target.value = "";
+});
+
+stage.addEventListener("dragover", (evt) => evt.preventDefault());
+stage.addEventListener("drop", async (evt) => {
+  evt.preventDefault();
+  const file = evt.dataTransfer?.files?.[0];
+  if (!file || !file.name.endsWith(".svg")) return;
+  const text = await file.text();
+  importSvgText(text);
+});
+
+byId("bringFrontBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  recordHistory();
+  stage.appendChild(state.selected);
+  refreshLayerList();
+});
+
+byId("sendBackBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  recordHistory();
+  stage.insertBefore(state.selected, stage.firstChild);
+  refreshLayerList();
+});
+
+byId("duplicateBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  recordHistory();
+  const clone = state.selected.cloneNode(true);
+  clone.classList.remove("selected");
+  assignElementMetadata(clone);
+  stage.appendChild(clone);
+  selectElement(clone);
+});
+
+byId("deleteBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  recordHistory();
+  stage.removeChild(state.selected);
+  selectElement(null);
+  refreshLayerList();
+});
+
+byId("undoBtn").addEventListener("click", () => {
+  if (state.history.length === 0) return;
+  state.redo.push({
+    markup: stage.innerHTML,
+    viewBox: { ...state.viewBox },
+    shapeCount: state.shapeCount,
+    nextId: state.nextId
+  });
+  const previous = state.history.pop();
+  restoreState(previous);
+  statusEl.textContent = "Undo";
+});
+
+byId("redoBtn").addEventListener("click", () => {
+  if (state.redo.length === 0) return;
+  state.history.push({
+    markup: stage.innerHTML,
+    viewBox: { ...state.viewBox },
+    shapeCount: state.shapeCount,
+    nextId: state.nextId
+  });
+  const next = state.redo.pop();
+  restoreState(next);
+  statusEl.textContent = "Redo";
 });
 
 byId("clearBtn").addEventListener("click", () => {
+  recordHistory();
   while (stage.firstChild) stage.removeChild(stage.firstChild);
   selectElement(null);
   byId("animList").innerHTML = "";
+  refreshLayerList();
 });
 
 byId("exportBtn").addEventListener("click", () => {
@@ -250,3 +539,5 @@ byId("exportBtn").addEventListener("click", () => {
   URL.revokeObjectURL(url);
   statusEl.textContent = "Exported SVG";
 });
+
+refreshLayerList();

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
           <label>Tool</label>
           <div class="tool-row">
             <button class="tool is-active" data-tool="select">Select</button>
+            <button class="tool" data-tool="pan">Pan</button>
             <button class="tool" data-tool="rect">Rect</button>
             <button class="tool" data-tool="circle">Circle</button>
             <button class="tool" data-tool="path">Path</button>
@@ -36,12 +37,41 @@
           <label>Stroke width</label>
           <input id="strokeWidth" type="range" min="1" max="12" value="2" />
 
+          <div class="split-row">
+            <div>
+              <label>Snap to grid</label>
+              <button id="snapToggle">Snap: off</button>
+            </div>
+            <div>
+              <label>Grid size</label>
+              <input id="gridSize" type="number" min="4" max="80" value="24" />
+            </div>
+          </div>
+
           <label>Extrude depth</label>
           <input id="extrudeDepth" type="range" min="0" max="20" value="6" />
           <button id="extrudeBtn">Extrude selected</button>
+
+          <label>Viewport</label>
+          <div class="split-row">
+            <button id="zoomOutBtn">- Zoom</button>
+            <button id="zoomInBtn">+ Zoom</button>
+          </div>
+          <button id="resetViewBtn">Reset View</button>
         </section>
 
         <section class="panel" data-panel="animate">
+          <label>Animation templates</label>
+          <select id="animTemplate">
+            <option value="">Select a template</option>
+            <option value="float">Float</option>
+            <option value="pulse">Pulse</option>
+            <option value="spin">Spin</option>
+            <option value="fadeInOut">Fade in/out</option>
+            <option value="bounce">Bounce</option>
+          </select>
+          <button id="applyTemplateBtn">Apply template</button>
+
           <label>Animation type</label>
           <select id="animType">
             <option value="translate">Translate</option>
@@ -50,22 +80,77 @@
             <option value="opacity">Opacity</option>
           </select>
 
-          <label>From</label>
-          <input id="animFrom" type="text" value="0 0" />
+          <div class="split-row">
+            <div>
+              <label>From</label>
+              <input id="animFrom" type="text" value="0 0" />
+            </div>
+            <div>
+              <label>To</label>
+              <input id="animTo" type="text" value="80 0" />
+            </div>
+          </div>
 
-          <label>To</label>
-          <input id="animTo" type="text" value="80 0" />
+          <div class="split-row">
+            <div>
+              <label>Duration (s)</label>
+              <input id="animDur" type="number" min="0.1" step="0.1" value="2" />
+            </div>
+            <div>
+              <label>Delay (s)</label>
+              <input id="animDelay" type="number" min="0" step="0.1" value="0" />
+            </div>
+          </div>
 
-          <label>Duration (s)</label>
-          <input id="animDur" type="number" min="0.1" step="0.1" value="2" />
+          <div class="split-row">
+            <div>
+              <label>Easing</label>
+              <select id="animEase">
+                <option value="linear">Linear</option>
+                <option value="ease">Ease</option>
+                <option value="ease-in">Ease in</option>
+                <option value="ease-out">Ease out</option>
+                <option value="ease-in-out">Ease in/out</option>
+              </select>
+            </div>
+            <div>
+              <label>Repeat</label>
+              <select id="animRepeat">
+                <option value="indefinite">Infinite</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+              </select>
+            </div>
+          </div>
 
           <button id="addAnimBtn">Add key animation</button>
-          <button id="previewBtn">Preview all</button>
+          <button id="previewBtn">Restart preview</button>
 
           <ul id="animList"></ul>
         </section>
 
         <section class="panel" data-panel="export">
+          <label>Import</label>
+          <input id="importSvgInput" type="file" accept=".svg,image/svg+xml" />
+          <p class="hint">You can also drag and drop an SVG file onto the canvas.</p>
+
+          <label>Layer manager</label>
+          <ul id="layerList"></ul>
+          <div class="split-row">
+            <button id="bringFrontBtn">Bring Front</button>
+            <button id="sendBackBtn">Send Back</button>
+          </div>
+          <div class="split-row">
+            <button id="duplicateBtn">Duplicate</button>
+            <button id="deleteBtn">Delete</button>
+          </div>
+
+          <div class="split-row">
+            <button id="undoBtn">Undo</button>
+            <button id="redoBtn">Redo</button>
+          </div>
+
           <button id="clearBtn">Clear canvas</button>
           <button id="exportBtn">Export SVG</button>
           <p class="hint">Keeps shapes + animation tags.</p>

--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@ body {
 
 .app {
   display: grid;
-  grid-template-columns: 300px 1fr;
+  grid-template-columns: 340px 1fr;
   min-height: 100vh;
 }
 
@@ -25,6 +25,7 @@ body {
   border-right: 1px solid var(--line);
   background: var(--panel);
   padding: 16px;
+  overflow-y: auto;
 }
 
 h1 { margin: 0; font-size: 1.1rem; letter-spacing: 0.03em; }
@@ -63,11 +64,18 @@ label {
 
 .tool-row {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 6px;
 }
 
-#animList {
+.split-row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+
+#animList,
+#layerList {
   list-style: none;
   padding-left: 0;
   margin: 10px 0 0;
@@ -77,12 +85,18 @@ label {
   overflow: auto;
 }
 
-#animList li {
+#animList li,
+#layerList li {
   background: #1f1f1f;
   border: 1px solid var(--line);
   border-radius: 6px;
   padding: 6px;
   font-size: 0.75rem;
+}
+
+#layerList li.is-selected {
+  border-color: #ababab;
+  background: #2b2b2b;
 }
 
 .hint { color: var(--muted); font-size: 0.75rem; }
@@ -104,6 +118,11 @@ label {
     linear-gradient(90deg, #202020 1px, transparent 1px),
     #111;
   background-size: 24px 24px;
+  cursor: crosshair;
+}
+
+#stage.is-panning {
+  cursor: grabbing;
 }
 
 .selected {


### PR DESCRIPTION
### Motivation
- Make the Animate workflow substantially more useful by adding quick animation templates, manual controls (delay, easing, repeat) and a reliable preview flow.
- Add SVG import and drag/drop so users can bring artwork in and animate it without external tooling.
- Improve canvas navigation and editing by enabling pan/zoom and direct object movement, plus a handful of larger editor features for real-world workflows.

### Description
- UI: expanded `index.html` sidebar with a Pan tool, zoom controls, import file input, animation template picker, layer manager and buttons for bring/send/duplicate/delete/undo/redo.
- Styling: updated `styles.css` to widen the sidebar, add split-row layouts, layer-list styles and panning cursor feedback.
- Editor logic: refactored `assets/app.js` to add viewBox-based pan/zoom (mouse wheel, zoom buttons, space-to-pan and Pan tool), snap-to-grid, undo/redo history snapshots, layer list synchronization, element metadata assignment, duplicate/delete/ordering operations, extrude improvements, and SVG import (file input + drag/drop).
- Animation: unified animation pipeline with templates (float, pulse, spin, fadeInOut, bounce), support for delay/easing/repeat, and a restart-preview action that triggers `beginElement` on animations.

### Testing
- Ran `node --check assets/app.js` and the syntax check passed successfully.
- Attempted an automated browser screenshot with Playwright (served locally) but the headless Chromium in this environment crashed (SIGSEGV), so the visual preview test could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fa0ba4c08321a41983d500e7a7af)