### PR TITLE
Enhance animation workspace with SVG import, pan/zoom, templates, layers and editor tools

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,4 +1,6 @@
 const SVG_NS = "http://www.w3.org/2000/svg";
+const INITIAL_VIEWBOX = { x: 0, y: 0, width: 1200, height: 760 };
+const MAX_HISTORY = 60;
 const stage = document.getElementById("stage");
 const statusEl = document.getElementById("status");
 
@@ -11,15 +13,107 @@ const state = {
   dragOrigin: null,
   itemOrigin: null,
   pathPoints: [],
-  shapeCount: 0
+  shapeCount: 0,
+  panning: false,
+  viewBox: { ...INITIAL_VIEWBOX },
+  zoomPercent: 100,
+  history: [],
+  historyIndex: -1
 };
 
 const byId = (id) => document.getElementById(id);
+const topLevelShapes = () => [...stage.children].filter((el) => !el.matches("defs"));
+
 const getStyles = () => ({
   fill: byId("fillColor").value,
   stroke: byId("strokeColor").value,
   strokeWidth: byId("strokeWidth").value
 });
+
+const animationTemplates = {
+  "slide-right": { type: "translate", from: "0 0", to: "120 0", dur: 1.2, ease: "ease-in-out" },
+  bounce: { type: "translate", from: "0 0", to: "0 -45", dur: 0.7, ease: "ease-in-out" },
+  spin: { type: "rotate", from: "0 300 200", to: "360 300 200", dur: 2, ease: "linear" },
+  pulse: { type: "scale", from: "1 1", to: "1.3 1.3", dur: 0.8, ease: "ease-in-out" },
+  "fade-in-out": { type: "opacity", from: "0.15", to: "1", dur: 1.1, ease: "ease-in-out" }
+};
+
+const setViewBox = () => {
+  stage.setAttribute(
+    "viewBox",
+    `${state.viewBox.x} ${state.viewBox.y} ${state.viewBox.width} ${state.viewBox.height}`
+  );
+};
+
+const updateZoomRange = () => {
+  byId("zoomRange").value = String(Math.round(state.zoomPercent));
+};
+
+const saveHistory = () => {
+  const snapshot = {
+    content: stage.innerHTML,
+    viewBox: { ...state.viewBox },
+    shapeCount: state.shapeCount
+  };
+
+  state.history = state.history.slice(0, state.historyIndex + 1);
+  state.history.push(snapshot);
+  if (state.history.length > MAX_HISTORY) {
+    state.history.shift();
+  }
+  state.historyIndex = state.history.length - 1;
+};
+
+const applyHistory = (snapshot) => {
+  stage.innerHTML = snapshot.content;
+  state.viewBox = { ...snapshot.viewBox };
+  state.shapeCount = snapshot.shapeCount;
+  selectElement(null);
+  setViewBox();
+  refreshLayers();
+  rebuildAnimList();
+};
+
+const undo = () => {
+  if (state.historyIndex <= 0) return;
+  state.historyIndex -= 1;
+  applyHistory(state.history[state.historyIndex]);
+  statusEl.textContent = "Undo";
+};
+
+const redo = () => {
+  if (state.historyIndex >= state.history.length - 1) return;
+  state.historyIndex += 1;
+  applyHistory(state.history[state.historyIndex]);
+  statusEl.textContent = "Redo";
+};
+
+const refreshLayers = () => {
+  const layers = byId("layersList");
+  layers.innerHTML = "";
+  topLevelShapes()
+    .slice()
+    .reverse()
+    .forEach((el) => {
+      const li = document.createElement("li");
+      li.textContent = el.dataset.name || el.tagName;
+      if (el === state.selected) li.classList.add("is-active");
+      li.addEventListener("click", () => selectElement(el));
+      layers.appendChild(li);
+    });
+};
+
+const rebuildAnimList = () => {
+  const list = byId("animList");
+  list.innerHTML = "";
+  topLevelShapes().forEach((shape) => {
+    [...shape.querySelectorAll("animate, animateTransform")].forEach((anim) => {
+      const item = document.createElement("li");
+      item.textContent = `${shape.dataset.name || shape.tagName}: ${anim.tagName} ${anim.getAttribute("from") || ""} → ${anim.getAttribute("to") || ""}`;
+      list.appendChild(item);
+    });
+  });
+};
 
 const tabs = document.querySelectorAll(".tab");
 const panels = document.querySelectorAll(".panel");
@@ -50,6 +144,15 @@ const pointOnStage = (evt) => {
   return pt.matrixTransform(stage.getScreenCTM().inverse());
 };
 
+const snapPoint = (point) => {
+  if (!byId("snapToggle").checked) return point;
+  const size = Math.max(4, Number(byId("gridSize").value || 24));
+  return {
+    x: Math.round(point.x / size) * size,
+    y: Math.round(point.y / size) * size
+  };
+};
+
 const applyStyles = (el) => {
   const styles = getStyles();
   el.setAttribute("fill", styles.fill);
@@ -57,11 +160,18 @@ const applyStyles = (el) => {
   el.setAttribute("stroke-width", styles.strokeWidth);
 };
 
-const selectElement = (el) => {
+function selectElement(el) {
   if (state.selected) state.selected.classList.remove("selected");
   state.selected = el;
   if (el) el.classList.add("selected");
-};
+  refreshLayers();
+}
+
+const parsePolylinePoints = (pointStr) =>
+  pointStr
+    .trim()
+    .split(" ")
+    .map((pair) => pair.split(",").map(Number));
 
 const createShape = (tool, x, y) => {
   let el;
@@ -88,15 +198,28 @@ const createShape = (tool, x, y) => {
   el.dataset.name = `Shape ${++state.shapeCount}`;
   applyStyles(el);
   stage.appendChild(el);
+  refreshLayers();
   return el;
 };
 
+const startPan = (point) => {
+  state.panning = true;
+  state.dragOrigin = point;
+  state.itemOrigin = { x: state.viewBox.x, y: state.viewBox.y };
+};
+
 stage.addEventListener("mousedown", (evt) => {
-  const p = pointOnStage(evt);
+  const rawPoint = pointOnStage(evt);
+  const p = snapPoint(rawPoint);
   state.start = p;
 
+  if (state.tool === "pan") {
+    startPan(rawPoint);
+    return;
+  }
+
   if (state.tool === "select") {
-    const target = evt.target !== stage ? evt.target : null;
+    const target = evt.target !== stage ? evt.target.closest("g,rect,circle,polyline,path,ellipse,line,polygon") : null;
     selectElement(target);
     if (target) {
       state.dragging = true;
@@ -110,6 +233,9 @@ stage.addEventListener("mousedown", (evt) => {
       if (target.tagName === "polyline") {
         state.itemOrigin = target.getAttribute("points");
       }
+      if (target.tagName === "g") {
+        state.itemOrigin = target.getAttribute("transform") || "translate(0,0)";
+      }
     }
     return;
   }
@@ -119,7 +245,17 @@ stage.addEventListener("mousedown", (evt) => {
 });
 
 stage.addEventListener("mousemove", (evt) => {
-  const p = pointOnStage(evt);
+  const rawPoint = pointOnStage(evt);
+  const p = snapPoint(rawPoint);
+
+  if (state.panning) {
+    const dx = rawPoint.x - state.dragOrigin.x;
+    const dy = rawPoint.y - state.dragOrigin.y;
+    state.viewBox.x = state.itemOrigin.x - dx;
+    state.viewBox.y = state.itemOrigin.y - dy;
+    setViewBox();
+    return;
+  }
 
   if (state.dragging && state.selected) {
     const dx = p.x - state.dragOrigin.x;
@@ -134,13 +270,13 @@ stage.addEventListener("mousemove", (evt) => {
       el.setAttribute("cy", state.itemOrigin.y + dy);
     }
     if (el.tagName === "polyline") {
-      const moved = state.itemOrigin
-        .trim()
-        .split(" ")
-        .map((pair) => pair.split(",").map(Number))
+      const moved = parsePolylinePoints(state.itemOrigin)
         .map(([x, y]) => `${x + dx},${y + dy}`)
         .join(" ");
       el.setAttribute("points", moved);
+    }
+    if (el.tagName === "g") {
+      el.setAttribute("transform", `translate(${dx}, ${dy})`);
     }
     return;
   }
@@ -167,11 +303,46 @@ stage.addEventListener("mousemove", (evt) => {
 });
 
 window.addEventListener("mouseup", () => {
+  if (state.drawing || state.dragging || state.panning) saveHistory();
   state.drawing = null;
   state.start = null;
   state.dragging = false;
+  state.panning = false;
   state.dragOrigin = null;
   state.itemOrigin = null;
+});
+
+stage.addEventListener("wheel", (evt) => {
+  evt.preventDefault();
+  const scale = evt.deltaY > 0 ? 1.08 : 0.92;
+  const pointer = pointOnStage(evt);
+  state.viewBox.width *= scale;
+  state.viewBox.height *= scale;
+  state.viewBox.x = pointer.x - ((pointer.x - state.viewBox.x) * scale);
+  state.viewBox.y = pointer.y - ((pointer.y - state.viewBox.y) * scale);
+  state.zoomPercent = (INITIAL_VIEWBOX.width / state.viewBox.width) * 100;
+  setViewBox();
+  updateZoomRange();
+}, { passive: false });
+
+byId("zoomRange").addEventListener("input", (evt) => {
+  const targetZoom = Number(evt.target.value);
+  const centerX = state.viewBox.x + state.viewBox.width / 2;
+  const centerY = state.viewBox.y + state.viewBox.height / 2;
+  state.zoomPercent = targetZoom;
+  state.viewBox.width = INITIAL_VIEWBOX.width * (100 / targetZoom);
+  state.viewBox.height = INITIAL_VIEWBOX.height * (100 / targetZoom);
+  state.viewBox.x = centerX - state.viewBox.width / 2;
+  state.viewBox.y = centerY - state.viewBox.height / 2;
+  setViewBox();
+});
+
+byId("resetViewBtn").addEventListener("click", () => {
+  state.viewBox = { ...INITIAL_VIEWBOX };
+  state.zoomPercent = 100;
+  setViewBox();
+  updateZoomRange();
+  statusEl.textContent = "Viewport reset";
 });
 
 byId("extrudeBtn").addEventListener("click", () => {
@@ -179,6 +350,7 @@ byId("extrudeBtn").addEventListener("click", () => {
   const depth = Number(byId("extrudeDepth").value);
   const base = state.selected;
   const group = document.createElementNS(SVG_NS, "g");
+  group.dataset.name = `${base.dataset.name || "Shape"} Extruded`;
   for (let i = depth; i >= 1; i -= 1) {
     const clone = base.cloneNode(true);
     clone.classList.remove("selected");
@@ -192,6 +364,7 @@ byId("extrudeBtn").addEventListener("click", () => {
   group.appendChild(top);
   stage.replaceChild(group, base);
   selectElement(group);
+  saveHistory();
   statusEl.textContent = "Extruded into layered group";
 });
 
@@ -201,6 +374,7 @@ const appendAnimation = () => {
   const from = byId("animFrom").value.trim();
   const to = byId("animTo").value.trim();
   const dur = Number(byId("animDur").value || 2);
+  const ease = byId("animEase").value;
 
   let anim;
   if (type === "opacity") {
@@ -217,26 +391,141 @@ const appendAnimation = () => {
   anim.setAttribute("to", to);
   anim.setAttribute("dur", `${dur}s`);
   anim.setAttribute("repeatCount", "indefinite");
-  state.selected.appendChild(anim);
+  anim.setAttribute("calcMode", "spline");
 
-  const li = document.createElement("li");
-  li.textContent = `${state.selected.dataset.name || state.selected.tagName}: ${type} ${from} → ${to} (${dur}s)`;
-  byId("animList").appendChild(li);
+  const splines = {
+    linear: "0 0 1 1",
+    "ease-in": "0.42 0 1 1",
+    "ease-out": "0 0 0.58 1",
+    "ease-in-out": "0.42 0 0.58 1"
+  };
+  anim.setAttribute("keyTimes", "0;1");
+  anim.setAttribute("keySplines", splines[ease]);
+
+  state.selected.appendChild(anim);
+  rebuildAnimList();
+  saveHistory();
 };
 
 byId("addAnimBtn").addEventListener("click", appendAnimation);
+
+byId("applyTemplateBtn").addEventListener("click", () => {
+  const template = animationTemplates[byId("animTemplate").value];
+  if (!template) return;
+  byId("animType").value = template.type;
+  byId("animFrom").value = template.from;
+  byId("animTo").value = template.to;
+  byId("animDur").value = String(template.dur);
+  byId("animEase").value = template.ease;
+  appendAnimation();
+  statusEl.textContent = `Template applied: ${byId("animTemplate").value}`;
+});
+
+byId("playBtn").addEventListener("click", () => {
+  stage.unpauseAnimations();
+  statusEl.textContent = "Animations playing";
+});
+
+byId("pauseBtn").addEventListener("click", () => {
+  stage.pauseAnimations();
+  statusEl.textContent = "Animations paused";
+});
+
+byId("clearAnimBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  state.selected.querySelectorAll("animate, animateTransform").forEach((el) => el.remove());
+  rebuildAnimList();
+  saveHistory();
+});
+
 byId("previewBtn").addEventListener("click", () => {
-  const clone = stage.cloneNode(true);
-  stage.replaceWith(clone);
-  clone.setAttribute("id", "stage");
+  stage.setCurrentTime(0);
+  stage.unpauseAnimations();
   statusEl.textContent = "Animation restarted";
-  window.location.reload();
+});
+
+byId("duplicateBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  const clone = state.selected.cloneNode(true);
+  clone.dataset.name = `Shape ${++state.shapeCount}`;
+  const existing = clone.getAttribute("transform") || "";
+  clone.setAttribute("transform", `${existing} translate(20,20)`.trim());
+  stage.appendChild(clone);
+  selectElement(clone);
+  saveHistory();
+});
+
+byId("deleteBtn").addEventListener("click", () => {
+  if (!state.selected) return;
+  state.selected.remove();
+  selectElement(null);
+  rebuildAnimList();
+  saveHistory();
+});
+
+byId("layerUpBtn").addEventListener("click", () => {
+  if (!state.selected || !state.selected.nextElementSibling) return;
+  stage.insertBefore(state.selected, state.selected.nextElementSibling.nextElementSibling);
+  refreshLayers();
+  saveHistory();
+});
+
+byId("layerDownBtn").addEventListener("click", () => {
+  if (!state.selected || !state.selected.previousElementSibling) return;
+  stage.insertBefore(state.selected, state.selected.previousElementSibling);
+  refreshLayers();
+  saveHistory();
+});
+
+byId("svgImport").addEventListener("change", async (evt) => {
+  const file = evt.target.files?.[0];
+  if (!file) return;
+  const text = await file.text();
+  const parsed = new DOMParser().parseFromString(text, "image/svg+xml");
+  const importedSvg = parsed.querySelector("svg");
+  if (!importedSvg) {
+    statusEl.textContent = "Invalid SVG file";
+    return;
+  }
+
+  importedSvg.querySelectorAll("script, foreignObject").forEach((node) => node.remove());
+  [...importedSvg.children].forEach((child) => {
+    const clone = document.importNode(child, true);
+    if (!clone.dataset.name) clone.dataset.name = `Shape ${++state.shapeCount}`;
+    stage.appendChild(clone);
+  });
+
+  evt.target.value = "";
+  refreshLayers();
+  rebuildAnimList();
+  saveHistory();
+  statusEl.textContent = "SVG imported";
+});
+
+byId("undoBtn").addEventListener("click", undo);
+byId("redoBtn").addEventListener("click", redo);
+
+window.addEventListener("keydown", (evt) => {
+  if (evt.key === "Delete" && state.selected) {
+    byId("deleteBtn").click();
+  }
+  if ((evt.ctrlKey || evt.metaKey) && evt.key.toLowerCase() === "z") {
+    evt.preventDefault();
+    if (evt.shiftKey) redo();
+    else undo();
+  }
+  if ((evt.ctrlKey || evt.metaKey) && evt.key.toLowerCase() === "d") {
+    evt.preventDefault();
+    byId("duplicateBtn").click();
+  }
 });
 
 byId("clearBtn").addEventListener("click", () => {
   while (stage.firstChild) stage.removeChild(stage.firstChild);
   selectElement(null);
   byId("animList").innerHTML = "";
+  refreshLayers();
+  saveHistory();
 });
 
 byId("exportBtn").addEventListener("click", () => {
@@ -250,3 +539,8 @@ byId("exportBtn").addEventListener("click", () => {
   URL.revokeObjectURL(url);
   statusEl.textContent = "Exported SVG";
 });
+
+setViewBox();
+updateZoomRange();
+refreshLayers();
+saveHistory();

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
           <label>Tool</label>
           <div class="tool-row">
             <button class="tool is-active" data-tool="select">Select</button>
+            <button class="tool" data-tool="pan">Pan</button>
             <button class="tool" data-tool="rect">Rect</button>
             <button class="tool" data-tool="circle">Circle</button>
             <button class="tool" data-tool="path">Path</button>
@@ -36,9 +37,30 @@
           <label>Stroke width</label>
           <input id="strokeWidth" type="range" min="1" max="12" value="2" />
 
+          <div class="inline-actions">
+            <button id="duplicateBtn">Duplicate selected</button>
+            <button id="deleteBtn">Delete selected</button>
+          </div>
+
+          <label>Grid</label>
+          <div class="grid-row">
+            <label class="check"><input id="snapToggle" type="checkbox" /> Snap to grid</label>
+            <input id="gridSize" type="number" min="4" max="64" value="24" />
+          </div>
+
+          <label>Import SVG</label>
+          <input id="svgImport" type="file" accept=".svg,image/svg+xml" />
+
           <label>Extrude depth</label>
           <input id="extrudeDepth" type="range" min="0" max="20" value="6" />
           <button id="extrudeBtn">Extrude selected</button>
+
+          <label>Layers</label>
+          <ul id="layersList"></ul>
+          <div class="inline-actions">
+            <button id="layerUpBtn">Bring forward</button>
+            <button id="layerDownBtn">Send backward</button>
+          </div>
         </section>
 
         <section class="panel" data-panel="animate">
@@ -59,13 +81,46 @@
           <label>Duration (s)</label>
           <input id="animDur" type="number" min="0.1" step="0.1" value="2" />
 
-          <button id="addAnimBtn">Add key animation</button>
-          <button id="previewBtn">Preview all</button>
+          <label>Easing</label>
+          <select id="animEase">
+            <option value="linear">Linear</option>
+            <option value="ease-in">Ease in</option>
+            <option value="ease-out">Ease out</option>
+            <option value="ease-in-out">Ease in out</option>
+          </select>
+
+          <label>Animation templates</label>
+          <select id="animTemplate">
+            <option value="slide-right">Slide right</option>
+            <option value="bounce">Bounce</option>
+            <option value="spin">Spin</option>
+            <option value="pulse">Pulse</option>
+            <option value="fade-in-out">Fade in/out</option>
+          </select>
+          <button id="applyTemplateBtn">Apply template</button>
+
+          <div class="inline-actions">
+            <button id="addAnimBtn">Add key animation</button>
+            <button id="clearAnimBtn">Clear selected animations</button>
+          </div>
+
+          <div class="inline-actions">
+            <button id="playBtn">Play</button>
+            <button id="pauseBtn">Pause</button>
+            <button id="previewBtn">Restart preview</button>
+          </div>
 
           <ul id="animList"></ul>
         </section>
 
         <section class="panel" data-panel="export">
+          <div class="inline-actions">
+            <button id="undoBtn">Undo</button>
+            <button id="redoBtn">Redo</button>
+          </div>
+          <label>Viewport</label>
+          <input id="zoomRange" type="range" min="20" max="300" value="100" />
+          <button id="resetViewBtn">Reset zoom & pan</button>
           <button id="clearBtn">Clear canvas</button>
           <button id="exportBtn">Export SVG</button>
           <p class="hint">Keeps shapes + animation tags.</p>

--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@ body {
 
 .app {
   display: grid;
-  grid-template-columns: 300px 1fr;
+  grid-template-columns: 320px 1fr;
   min-height: 100vh;
 }
 
@@ -25,6 +25,8 @@ body {
   border-right: 1px solid var(--line);
   background: var(--panel);
   padding: 16px;
+  max-height: 100vh;
+  overflow-y: auto;
 }
 
 h1 { margin: 0; font-size: 1.1rem; letter-spacing: 0.03em; }
@@ -67,6 +69,28 @@ label {
   gap: 6px;
 }
 
+.inline-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.grid-row {
+  display: grid;
+  grid-template-columns: 1fr 80px;
+  gap: 8px;
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink);
+  margin: 0;
+}
+
+#layersList,
 #animList {
   list-style: none;
   padding-left: 0;
@@ -77,12 +101,18 @@ label {
   overflow: auto;
 }
 
+#layersList li,
 #animList li {
   background: #1f1f1f;
   border: 1px solid var(--line);
   border-radius: 6px;
   padding: 6px;
   font-size: 0.75rem;
+}
+
+#layersList li.is-active {
+  border-color: #a0a0a0;
+  background: #2a2a2a;
 }
 
 .hint { color: var(--muted); font-size: 0.75rem; }


### PR DESCRIPTION
### Motivation
- Make the Animate workflow substantially more useful by adding import, templates, and playback controls so users can create and iterate faster.
- Improve canvas navigation and editing precision with pan/zoom, grid snapping and a layers view to move and manage artwork.
- Provide basic editor tooling (duplicate/delete, extrude, undo/redo) so simple animations and composition tasks can be done inside the app.

### Description
- Expanded sidebar UI and panels in `index.html` to add Pan tool, SVG import input, grid snap, duplicate/delete, layers list with reorder buttons, animation templates, easing selector, play/pause/restart, zoom slider and undo/redo controls.
- Implemented viewBox-based pan/zoom, snap-to-grid, history stack, layer refresh, SVG import parsing/sanitization, animation templates and easing splines in `assets/app.js`, and added helper utilities such as `saveHistory`, `applyHistory`, `setViewBox`, and `rebuildAnimList`.
- Improved shape/group handling (support for translating `g` groups when dragging), extrude now produces named grouped layers, and export still serializes shapes + animation tags using the existing exporter.
- Updated layout/styling in `styles.css` to accommodate the new controls and panels while keeping the original dark UI look.

### Testing
- Ran `node --check assets/app.js` to validate the modified JavaScript syntax and it succeeded.
- Attempted an automated UI snapshot via Playwright to validate the page, but the headless browser could not reach the local preview server (navigation returned `ERR_EMPTY_RESPONSE`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fa0ba4c08321a41983d500e7a7af)